### PR TITLE
When installing, create any missing parent dirs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ INSTALLDIR?=$(PREFIX)
 INSTALL=install
 
 install:
-	${INSTALL} -m755 git-fixup ${INSTALLDIR}/bin/git-fixup
+	${INSTALL} -d -m755 git-fixup ${INSTALLDIR}/bin/git-fixup
 
 install-zsh:
-	mkdir -p ${INSTALLDIR}/share/zsh/site-functions/
-	${INSTALL} -m755 completion.zsh ${INSTALLDIR}/share/zsh/site-functions/_git-fixup
+	${INSTALL} -d -m755 completion.zsh ${INSTALLDIR}/share/zsh/site-functions/_git-fixup


### PR DESCRIPTION
Adding the `-d` flag to `install` also renders the `mkdir` command redundant in the `install-zsh` target, so I removed that line as well.