### PR TITLE
redirect error message to stderr

### DIFF
--- a/git-fixup
+++ b/git-fixup
@@ -54,7 +54,7 @@ if test $# -eq 1; then
 fi
 
 if git diff --cached --quiet; then
-    echo 'No staged changes. Use git add -p to add them.'
+    echo 'No staged changes. Use git add -p to add them.' >&2
     exit 1
 fi
 


### PR DESCRIPTION
This partly fixes #19 but introduces some weird output instead. But it
should be slightly better as at least the full error message is visible.