### PR TITLE
add support for squashing with the `-s` or `--squash` params

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ $ git fixup <ref>
 $ git rebase -i ...
 ```
 
+### Squashing
+
+`git-fixup` also supports squashing commits when you pass the `-s` or
+`--squash` command-line flag.  This is equivalent to using `git commit
+--squash <ref>`.
+
+    $ git fixup --squash <ref>
+
+Squashing gives you the opportunity to edit the commit message before
+the commits are squashed together.
+
 ## Tab completion
 
 The suggestions for the tab completion is the suggested fixup bases as

--- a/git-fixup
+++ b/git-fixup
@@ -47,10 +47,17 @@ function print_sha () {
     git --no-pager log --format="%H [$type] %s <%ae>" -n 1 "$sha"
 }
 
+op="fixup"
+case "$1" in
+    -s|--squash)
+        op="squash"
+        shift
+        ;;
+esac
+
 if test $# -eq 1; then
-    git rev-parse --verify "$1" > /dev/null || exit 1
-    git commit -m "fixup! $1";
-    exit 0
+    git commit --$op=$1
+    exit
 fi
 
 if git diff --cached --quiet; then


### PR DESCRIPTION
$ git-fixup -s 492aa0b
    [master 2f9b858] squash! 492aa0b10fbf5365c4ab447359223db950f22ad0

The flag must be provided before the git rev.