### PR TITLE
update zsh completion script

### DIFF
--- a/completion.zsh
+++ b/completion.zsh
@@ -1,7 +1,15 @@
 #compdef git-fixup
-local lines words
 
-lines=(${(f)"$(git fixup)"})
-words=(${(f)"$(git fixup | cut -d' ' -f 1)"})
+function _fixup_target {
+    local -a lines commits
 
-compadd -l -d lines -a -- words
+    lines=(${(f)"$(git fixup)"}) 2>&1 | read err
+    if [ $#lines -eq 0 ]; then
+        _message $err
+        return 1
+    fi
+    commits=(${lines[@]%% *})
+    compadd -l -d lines -a -- commits
+}
+
+_arguments ':commit:_fixup_target'


### PR DESCRIPTION
Rewrite to use the `_arguments` helper and a function providing the
fixup bases which also was improved to not call git-fixup twice.

If git-fixup does not yield any commits to use the output to stderr will
be displayed using `_message`