### PR TITLE
Exclude other fixups from recent commits

### DIFF
--- a/git-fixup
+++ b/git-fixup
@@ -34,7 +34,7 @@ function fixup_candidates_lines () {
 function fixup_candidates_files () {
     git diff --cached --name-only | (
         while read file; do
-            git rev-list -n 1 $rev_range -- $file
+            git rev-list -n 1 -E --invert-grep --grep='^(fixup|squash)' $rev_range -- $file
         done
     ) | sed 's/^/F /g'
 }


### PR DESCRIPTION
When generating candidates based on most recent commit to each change
file it can easily happen that the last commit is a fixup created
moments ago. This is not very useful as doing a 2nd fixup of the same
original commit will have the same effect and it's more likely to be
shadowing a commit you actually want to fix.

Add a inverted grep for commit messages starting the line with fixup or
squash when calling rev-list

@fixe @joeshaw  does this look reasonble to you guys?