### PR TITLE
Don't use symmetrical rev range

### DIFF
--- a/git-fixup
+++ b/git-fixup
@@ -71,7 +71,7 @@ head=`git rev-parse HEAD 2>/dev/null`
 if test -z "$upstream" -o "$upstream" = "$head"; then
     rev_range="HEAD"
 else
-    rev_range="@{upstream}...HEAD"
+    rev_range="@{upstream}..HEAD"
 fi
 
 (


### PR DESCRIPTION
The triple dot notation in rev ranges is different to git diff and
rev-list (and blame). In the case of log it would cause commits on
@{upstream} not in the merge base to be included which is causing blame
to exit with a fatal error.