### PR TITLE
Use DESTDIR in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ INSTALLDIR?=$(PREFIX)
 INSTALL=install
 
 install:
-	${INSTALL} -d ${INSTALLDIR}/bin
-	${INSTALL} -m755 git-fixup ${INSTALLDIR}/bin/git-fixup
+	${INSTALL} -d ${DESTDIR}${INSTALLDIR}/bin
+	${INSTALL} -m755 git-fixup ${DESTDIR}${INSTALLDIR}/bin/git-fixup
 
 install-zsh:
-	${INSTALL} -d ${INSTALLDIR}/share/zsh/site-functions
-	${INSTALL} -m755 completion.zsh ${INSTALLDIR}/share/zsh/site-functions/_git-fixup
+	${INSTALL} -d ${DESTDIR}${INSTALLDIR}/share/zsh/site-functions
+	${INSTALL} -m755 completion.zsh ${DESTDIR}${INSTALLDIR}/share/zsh/site-functions/_git-fixup


### PR DESCRIPTION
Hi,

I would like to package git-fixup for the gentoo distribution since I found it useful and would like to share it with my fellow workers (we are a few to be on gentoo).

The problem is, I discovered that the Makefile of your project doesn't use the `$DESTDIR` variable to allow installation to another place, which is almost mandatory on gentoo.

I hope it won't bother you to add them!

Cheers