### PR TITLE
Fix completion for Zsh 5.3

### DIFF
--- a/completion.zsh
+++ b/completion.zsh
@@ -3,11 +3,12 @@
 function _fixup_target {
     local -a lines commits
 
-    lines=(${(f)"$(git fixup)"}) 2>&1 | read err
-    if [ $#lines -eq 0 ]; then
-        _message $err
+    lines=(${(f)"$(git fixup 2>&1)"})
+    if test $? -ne 0; then
+        _message ${(F)lines}
         return 1
     fi
+
     commits=(${lines[@]%% *})
     compadd -l -d lines -a -- commits
 }


### PR DESCRIPTION
In Zsh 5.3, the construct `foo=bar | stuff` will no longer leave foo set (which
was accidental), so separating stdout and stderr this way no longer works.
However, it’s not strictly necessary to do so, since the exit status will also
signal failure conditions.
    
Fixes #35