### PR TITLE
Return just the latest commit in which the files have been touched

### DIFF
--- a/git-fixup
+++ b/git-fixup
@@ -34,7 +34,7 @@ function fixup_candidates_lines () {
 function fixup_candidates_files () {
     git diff --cached --name-only | (
         while read file; do
-            git rev-list -n 1 -E --invert-grep --grep='^(fixup|squash)' $rev_range -- $file
+            git rev-list -n 1 -E --invert-grep --grep='^(fixup|squash)' $rev_range -- $file|head -1
         done
     ) | sed 's/^/F /g'
 }


### PR DESCRIPTION
and not all of them.

Fix issue described on https://github.com/keis/git-fixup/commit/f3eec22373576b51e97eefb871f40d303bb42928#commitcomment-21947008

Gosh, it would be convenient, if the reporter created a proper issue!