### PR TITLE
replace readarray

### DIFF
--- a/git-fixup
+++ b/git-fixup
@@ -70,8 +70,8 @@ function print_candidates() {
 
 function fallback_menu() {
     (
-        readarray -t options
         IFS=$'\n'
+        read -d '' -ra options
         PS3="Which commit should I $op? "
         select line in "${options[@]}"; do
             if test -z "$line"; then


### PR DESCRIPTION
Use read instead of readarray because the latter is only bash >= 4 which isn't available on mac os.