### PR TITLE
No-verify: doc and completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ in the git config.
 
 Don't show the commit menu even if previously instructed to do so.
 
+### --no-verify
+
+Bypass the pre-commit and commit-msg hooks. (see `git help commit`)
+
 ## Configuration
 
 `git-fixup` uses configuration from the ENVIRONMENT or from `git config`

--- a/completion.fish
+++ b/completion.fish
@@ -7,4 +7,5 @@ end
 complete -c git -n '__fish_git_using_command fixup' -s s -l squash -f -d 'create a squash commit rather than a fixup'
 complete -c git -n '__fish_git_using_command fixup' -s c -l commit -f -d 'show a menu to pick a commit'
 complete -c git -n '__fish_git_using_command fixup' -l no-commit -f -d 'don\'t show a menu to pick a commit'
+complete -c git -n '__fish_git_using_command fixup' -l no-verify -f -d 'bypass the pre-commit and commit-msg hooks'
 complete -c git -n '__fish_git_using_command fixup' -f -k -a '(__fish_git_fixup_target)'

--- a/completion.zsh
+++ b/completion.zsh
@@ -18,4 +18,5 @@ _arguments -A \
     '(-s --squash)'{-s,--squash}'[create a squash commit rather than a fixup]' \
     '(-c --commit --no-commit)'{-c,--commit}'[create commit]' \
     '(-c --commit --no-commit)'--no-commit'[do not create commit]' \
+    '(--no-verify)'--no-verify'[bypass the pre-commit and commit-msg hooks]' \
     ':commit:_fixup_target'


### PR DESCRIPTION
- Updated the shell completions with `--no-verify`. I did test fish but not zsh.
- Updated the README