### PR TITLE
Add --base option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ script into your `$PATH` and `$fpath` respectively.
 
 ```
 git-fixup [-s|--squash] [-f|--fixup] [-c|--commit] [--no-verify]
-          [-b|--base <rev>] [-a|--autobase] [<ref>]
+          [-b|--base <rev>] [<ref>]
 ```
 
 For this tool to make any sense you should enable the `rebase.autosquash`
@@ -105,31 +105,33 @@ Don't show the commit menu even if previously instructed to do so.
 
 Bypass the pre-commit and commit-msg hooks. (see `git help commit`)
 
-### --base and --autobase
 
-The default revision range used for search for candidate commits is
-`@{upstream}..HEAD` when the current head contains an upstream branch or all
-commits reachable from `HEAD` otherwise.
+### --base <rev>
 
-You can override this behavior by passing an explicit revision to use as base
-of the range via `--base <rev>` (or `-b <ref>`), which will make `git-fixup`
-look for candidates in the range `<rev>..HEAD`.
+This option receives as argument the revision to be used as base commit for
+the search of fixup/squash candidates. You can use anything that resolves to a
+commit. The special value `closest` resolves to the closest ancestor branch of
+the current head.
 
-You can also instruct `git-fixup` to use the closest ancestor branch as base
-by using `--autobase` (or `-a`). You can use `git config fixup.autobase true`
-if you desire that to be the default behavior (which can then be overriden
-with `--no-autobase` for specific cases).
+If omitted, the default base commit is resolved in the following order:
+
+1. The value of the environment variable `GITFIXUPBASE` if present;
+2. The value of the configuration key `fixup.base` if present;
+3. The branch configured as upstream of the current one (i.e. `@{upstream}`)
+   if existing;
+4. Finally, the root commit (i.e. full history) if nothing of the above is
+   satisfied.
 
 ## Configuration
 
 `git-fixup` uses configuration from the ENVIRONMENT or from `git config`
 
-### fixup.autobase
+### fixup.base
 
-Or `GITFIXUPAUTOBASE`
+Or `GITFIXUPBASE`
 
-Boolean configuration to tell `git-fixup` to implicitly use `--autobase`
-option.
+The default argument for `--base`. You can set the value `closest` to make
+`git-fixup` use the closest ancestor branch by default, for example.
 
 ### fixup.action
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ script into your `$PATH` and `$fpath` respectively.
 
 ## Usage
 
-`git-fixup [-s|--squash] [-f|--fixup] [-c|--commit] [--no-verify] [<ref>]`
+```
+git-fixup [-s|--squash] [-f|--fixup] [-c|--commit] [--no-verify]
+          [-b|--base <rev>] [-a|--autobase] [<ref>]
+```
 
 For this tool to make any sense you should enable the `rebase.autosquash`
 setting in the git config.
@@ -102,9 +105,31 @@ Don't show the commit menu even if previously instructed to do so.
 
 Bypass the pre-commit and commit-msg hooks. (see `git help commit`)
 
+### --base and --autobase
+
+The default revision range used for search for candidate commits is
+`@{upstream}..HEAD` when the current head contains an upstream branch or all
+commits reachable from `HEAD` otherwise.
+
+You can override this behavior by passing an explicit revision to use as base
+of the range via `--base <rev>` (or `-b <ref>`), which will make `git-fixup`
+look for candidates in the range `<rev>..HEAD`.
+
+You can also instruct `git-fixup` to use the closest ancestor branch as base
+by using `--autobase` (or `-a`). You can use `git config fixup.autobase true`
+if you desire that to be the default behavior (which can then be overriden
+with `--no-autobase` for specific cases).
+
 ## Configuration
 
 `git-fixup` uses configuration from the ENVIRONMENT or from `git config`
+
+### fixup.autobase
+
+Or `GITFIXUPAUTOBASE`
+
+Boolean configuration to tell `git-fixup` to implicitly use `--autobase`
+option.
 
 ### fixup.action
 

--- a/git-fixup
+++ b/git-fixup
@@ -10,9 +10,7 @@ f,fixup       Create a fixup! commit
 c,commit      Show a menu from which to pick a commit
 no-commit     Don't show a menu to pick a commit
 no-verify     Bypass the pre-commit and commit-msg hooks
-b,base=rev    Use <rev> as base ancestor for candidate search
-a,autobase    Use the first ancestor branch as base for candidate search
-no-autobase   The inverse of --autobase
+b,base=rev    Use <rev> as base of the revision range for the search
 "
 SUBDIRECTORY_OK=yes
 . "$(git --exec-path)/git-sh-setup"
@@ -129,8 +127,7 @@ target=
 op=${GITFIXUPACTION:-$(git config --default=fixup fixup.action)}
 fixup_menu=${GITFIXUPMENU:-$(git config --default="" fixup.menu)}
 create_commit=${GITFIXUPCOMMIT:-$(git config --default=false --type bool fixup.commit)}
-autobase=${GITFIXUPAUTOBASE:-$(git config --default=false --type bool fixup.autobase)}
-base_ancestor=
+base=${GITFIXUPBASE:-$(git config --default="" fixup.base)}
 
 while test $# -gt 0; do
     case "$1" in
@@ -149,15 +146,12 @@ while test $# -gt 0; do
         --no-verify)
             git_commit_args+=($1)
             ;;
-        -a|--autobase)
-            autobase=true
-            ;;
-        --no-autobase)
-            autobase=false
-            ;;
         -b|--base)
             shift
-            base_ancestor="$1"
+            if test $# -eq 0; then
+                die "--base requires an argument"
+            fi
+            base="$1"
             ;;
         --)
             shift
@@ -176,35 +170,37 @@ if ! test -z "$target"; then
     exit
 fi
 
-if test -z "$base_ancestor" -a "$autobase" = "true"; then
-    base_ancestor=$(git for-each-ref \
-        --merged HEAD~1 \
-        --sort=-committerdate \
-        refs/heads/ \
-        --count 1 \
-        --format='%(objectname)' \
-    )
-    if test -z "$base_ancestor"; then
-        die "Could not find the ancestor branch"
-    fi
-fi
-
 if git diff --cached --quiet; then
     die 'No staged changes. Use git add -p to add them.'
 fi
 
 cd_to_toplevel
 
-if test -n "$base_ancestor"; then
-    rev_range="$base_ancestor..HEAD"
-else
+if test "$base" == "closest"; then
+    base=$(git for-each-ref \
+        --merged HEAD~1 \
+        --sort=-committerdate \
+        refs/heads/ \
+        --count 1 \
+        --format='%(objectname)' \
+    )
+    if test -z "$base"; then
+        die "Could not find the ancestor branch"
+    fi
+fi
+
+if test -z "$base"; then
     upstream=`git rev-parse @{upstream} 2>/dev/null`
     head=`git rev-parse HEAD 2>/dev/null`
-    if test -z "$upstream" -o "$upstream" = "$head"; then
-        rev_range="HEAD"
-    else
-        rev_range="@{upstream}..HEAD"
+    if test -n "$upstream" -a "$upstream" != "$head"; then
+        base="$upstream"
     fi
+fi
+
+if test -n "$base"; then
+    rev_range="$base..HEAD"
+else
+    rev_range="HEAD"
 fi
 
 if test "$create_commit" == "true"; then

--- a/git-fixup
+++ b/git-fixup
@@ -4,12 +4,15 @@
 OPTIONS_SPEC="\
 git fixup [options] [<ref>]
 --
-h,help     Show this help text
-s,squash   Create a squash! commit
-f,fixup    Create a fixup! commit
-c,commit   Show a menu from which to pick a commit
-no-commit  Don't show a menu to pick a commit
-no-verify  Bypass the pre-commit and commit-msg hooks
+h,help        Show this help text
+s,squash      Create a squash! commit
+f,fixup       Create a fixup! commit
+c,commit      Show a menu from which to pick a commit
+no-commit     Don't show a menu to pick a commit
+no-verify     Bypass the pre-commit and commit-msg hooks
+b,base=rev    Use <rev> as base ancestor for candidate search
+a,autobase    Use the first ancestor branch as base for candidate search
+no-autobase   The inverse of --autobase
 "
 SUBDIRECTORY_OK=yes
 . "$(git --exec-path)/git-sh-setup"
@@ -126,6 +129,8 @@ target=
 op=${GITFIXUPACTION:-$(git config --default=fixup fixup.action)}
 fixup_menu=${GITFIXUPMENU:-$(git config --default="" fixup.menu)}
 create_commit=${GITFIXUPCOMMIT:-$(git config --default=false --type bool fixup.commit)}
+autobase=${GITFIXUPAUTOBASE:-$(git config --default=false --type bool fixup.autobase)}
+base_ancestor=
 
 while test $# -gt 0; do
     case "$1" in
@@ -144,6 +149,16 @@ while test $# -gt 0; do
         --no-verify)
             git_commit_args+=($1)
             ;;
+        -a|--autobase)
+            autobase=true
+            ;;
+        --no-autobase)
+            autobase=false
+            ;;
+        -b|--base)
+            shift
+            base_ancestor="$1"
+            ;;
         --)
             shift
             break
@@ -161,17 +176,35 @@ if ! test -z "$target"; then
     exit
 fi
 
+if test -z "$base_ancestor" -a "$autobase" = "true"; then
+    base_ancestor=$(git for-each-ref \
+        --merged HEAD~1 \
+        --sort=-committerdate \
+        refs/heads/ \
+        --count 1 \
+        --format='%(objectname)' \
+    )
+    if test -z "$base_ancestor"; then
+        die "Could not find the ancestor branch"
+    fi
+fi
+
 if git diff --cached --quiet; then
     die 'No staged changes. Use git add -p to add them.'
 fi
 
 cd_to_toplevel
-upstream=`git rev-parse @{upstream} 2>/dev/null`
-head=`git rev-parse HEAD 2>/dev/null`
-if test -z "$upstream" -o "$upstream" = "$head"; then
-    rev_range="HEAD"
+
+if test -n "$base_ancestor"; then
+    rev_range="$base_ancestor..HEAD"
 else
-    rev_range="@{upstream}..HEAD"
+    upstream=`git rev-parse @{upstream} 2>/dev/null`
+    head=`git rev-parse HEAD 2>/dev/null`
+    if test -z "$upstream" -o "$upstream" = "$head"; then
+        rev_range="HEAD"
+    else
+        rev_range="@{upstream}..HEAD"
+    fi
 fi
 
 if test "$create_commit" == "true"; then


### PR DESCRIPTION
Hi there!

This is particularly useful for when the local development branch has diverged from its remote counterpart due to a previous rebase. This was the main motivation for me to implement such a feature.

Best regards,  
Gustavo Sousa