### PR TITLE
Recover lost `git fixup <ref>` functionality

### DIFF
--- a/git-fixup
+++ b/git-fixup
@@ -161,6 +161,7 @@ while test $# -gt 0; do
     shift
 done
 
+target="$1"
 if test $# -gt 1; then
     die "Pass only one ref, please"
 fi


### PR DESCRIPTION
On d3a301b27b347bb9cde4195ae8d64754262cd7c6 there was a code move that accidentally removed the `target=$1` functionality, forcing the tool to always use the menu instead of using the provided ref

Let me know if I'm missing something (the original commit had a shift, for example), but I think this should be ready to go.
