### PR TITLE
Add `--rebase` option that calls rebase after commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ script into your `$PATH` and `$fpath` respectively.
 
 ```
 git-fixup [-s|--squash] [-f|--fixup] [-c|--commit] [--no-verify]
-          [-b|--base <rev>] [<ref>]
+          [--rebase] [-b|--base <rev>] [<ref>]
 ```
 
 For this tool to make any sense you should enable the `rebase.autosquash`
-setting in the git config.
+setting in the git config, or use the `--rebase` option.
 
 
 ```bash
@@ -101,6 +101,21 @@ in the git config.
 
 Don't show the commit menu even if previously instructed to do so.
 
+### --rebase
+
+Call an interactive rebase right after the commit is created, to automatically apply the
+fix-up into the target commit. This is merely to avoid doing two commands one after the
+other (`git fixup && git rebase`).
+
+This simply calls `git rebase --interactive --autosquash target~1`, with the target being the
+commit to fix-up.
+
+Default rebase/no-rebase can be configured by setting [fixup.rebase](#fixuprebase)
+
+### --no-rebase
+
+Don't do a rebase even if previously instructed to do so (useful to bypass [fixup.rebase](#fixuprebase))
+
 ### --no-verify
 
 Bypass the pre-commit and commit-msg hooks. (see `git help commit`)
@@ -149,6 +164,17 @@ default.
 ```bash
 # Enable --commit for all my projects
 $ git config --global fixup.commit true
+```
+
+### fixup.rebase
+
+Or `GITFIXUPREBASE`
+
+Decides if `git rebase` should be called right after the `git commit` call.
+
+```bash
+# Enable --rebase for all my projects
+$ git config --global fixup.rebase true
 ```
 
 ### fixup.menu

--- a/completion.fish
+++ b/completion.fish
@@ -1,7 +1,7 @@
 # fish completion for git fixup
 
 function __fish_git_fixup_target
-    git fixup --no-commit 2>/dev/null | string replace -r '^([0-9a-f]{10})[0-9a-f]* (.*)' '$1\t$2'
+    git fixup --no-commit --no-rebase 2>/dev/null | string replace -r '^([0-9a-f]{10})[0-9a-f]* (.*)' '$1\t$2'
 end
 
 complete -c git -n '__fish_git_using_command fixup' -s s -l squash -f -d 'create a squash commit rather than a fixup'

--- a/completion.zsh
+++ b/completion.zsh
@@ -4,7 +4,7 @@
 function _fixup_target {
     local -a lines commits
 
-    lines=(${(f)"$(git fixup --no-commit 2>&1)"})
+    lines=(${(f)"$(git fixup --no-commit --no-rebase 2>&1)"})
     if test $? -ne 0; then
         _message ${(F)lines}
         return 1

--- a/git-fixup
+++ b/git-fixup
@@ -73,9 +73,7 @@ function call_commit() {
 function call_rebase() {
     local target=$1
 
-    has_parent=`git rev-parse --quiet --verify $target~1^{commit}`
-    ret_has_parent=$?
-    if [ $ret_has_parent -eq 0 ]; then
+    if git rev-parse --quiet --verify $target~1^{commit}; then
         git rebase --interactive --autosquash "$target~1"
     else
         git rebase --interactive --autosquash --root

--- a/git-fixup
+++ b/git-fixup
@@ -9,6 +9,8 @@ s,squash      Create a squash! commit
 f,fixup       Create a fixup! commit
 c,commit      Show a menu from which to pick a commit
 no-commit     Don't show a menu to pick a commit
+rebase        Do a rebase right after commit
+no-rebase     Don't do a rebase after commit
 no-verify     Bypass the pre-commit and commit-msg hooks
 b,base=rev    Use <rev> as base of the revision range for the search
 "
@@ -65,6 +67,19 @@ function call_commit() {
     local target=$1
 
     git commit ${git_commit_args[@]} --$op=$target
+}
+
+# Call git rebase
+function call_rebase() {
+    local target=$1
+
+    has_parent=`git rev-parse --quiet --verify $target~1^{commit}`
+    ret_has_parent=$?
+    if [ $ret_has_parent -eq 0 ]; then
+        git rebase --interactive --autosquash "$target~1"
+    else
+        git rebase --interactive --autosquash --root
+    fi
 }
 
 # Print list of fixup/squash candidates
@@ -125,6 +140,7 @@ show_menu () {
 git_commit_args=()
 target=
 op=${GITFIXUPACTION:-$(git config --default=fixup fixup.action)}
+rebase=${GITFIXUPREBASE:-$(git config --default=false fixup.rebase)}
 fixup_menu=${GITFIXUPMENU:-$(git config --default="" fixup.menu)}
 create_commit=${GITFIXUPCOMMIT:-$(git config --default=false --type bool fixup.commit)}
 base=${GITFIXUPBASE:-$(git config --default="" fixup.base)}
@@ -142,6 +158,12 @@ while test $# -gt 0; do
             ;;
         --no-commit)
             create_commit=false
+            ;;
+        --rebase)
+            rebase=true
+            ;;
+        --no-rebase)
+            rebase=false
             ;;
         --no-verify)
             git_commit_args+=($1)
@@ -168,6 +190,9 @@ fi
 
 if ! test -z "$target"; then
     call_commit $target
+    if test "$rebase" == "true"; then
+        call_rebase $target
+    fi
     exit
 fi
 
@@ -209,4 +234,8 @@ if test "$create_commit" == "true"; then
     ! test -z "$target" && call_commit ${target%% *}
 else
     print_candidates
+fi
+
+if test "$rebase" == "true"; then
+    ! test -z "$target" && call_rebase ${target%% *}
 fi

--- a/git-fixup
+++ b/git-fixup
@@ -73,9 +73,12 @@ function call_commit() {
 function call_rebase() {
     local target=$1
 
+    # If our target-commit has a parent, we call a rebase with that
     if git rev-parse --quiet --verify $target~1^{commit}; then
         git rebase --interactive --autosquash "$target~1"
-    else
+    # If our target-commit exists but has no parents, it must be the very first commit
+    # the repo. We simply call a rebase with --root
+    elif git rev-parse --quiet --verify $target^{commit}; then
         git rebase --interactive --autosquash --root
     fi
 }

--- a/git-fixup
+++ b/git-fixup
@@ -229,11 +229,13 @@ fi
 
 if test "$create_commit" == "true"; then
     target=$(print_candidates | show_menu)
-    ! test -z "$target" && call_commit ${target%% *}
+    if test -z "$target"; then
+        exit
+    fi
+    call_commit ${target%% *}
+    if test "$rebase" == "true"; then
+        call_rebase ${target%% *}
+    fi
 else
     print_candidates
-fi
-
-if test "$rebase" == "true"; then
-    ! test -z "$target" && call_rebase ${target%% *}
 fi


### PR DESCRIPTION
Taking the [idea](https://github.com/tummychow/git-absorb) from `git absorb` (a similar tool), I added a simple command line option to call `git rebase` after a commit was made with `git fixup`, instead of having to manually call `git rebase -i ...`

This can be configured as a default with the `fixup.rebase` git config option. This PR also adds the `--no-rebase` option, to bypass any default set.

(As a fun side note, if one would like to [not even have the interactive rebase editor appear](https://stackoverflow.com/a/37224000), you can make `GIT_SECUENCE_EDITOR` point to `touch` and have `git fixup <ref>` be entirely input-less: `GIT_SEQUENCE_EDITOR=touch git fixup <ref>`. Of course this could be made as a feature for `git-fixup`, but I think it shouldn't be one, due to the hacky nature of it).

The code accounts for fix up commits made to any commit in the repo, including the very first one, and works both when calling `git fixup` and `git fixup <ref>` (and also, for both `squash` and `fixup`). In terms of documentation, I don't know if my additions to the README are good or if there are some necessary changes to be made.

Let me know what you think, I freaking love this tool.