### PR TITLE
Add short option -n for --no-verify

### DIFF
--- a/completion.fish
+++ b/completion.fish
@@ -7,7 +7,7 @@ end
 complete -c git -n '__fish_git_using_command fixup' -s s -l squash -f -d 'Create a squash commit rather than a fixup'
 complete -c git -n '__fish_git_using_command fixup' -s c -l commit -f -d 'Show a menu to pick a commit'
 complete -c git -n '__fish_git_using_command fixup' -l no-commit -f -d 'Don\'t show a menu to pick a commit'
-complete -c git -n '__fish_git_using_command fixup' -l no-verify -f -d 'Bypass the pre-commit and commit-msg hooks'
+complete -c git -n '__fish_git_using_command fixup' -s n -l no-verify -f -d 'Bypass the pre-commit and commit-msg hooks'
 complete -c git -n '__fish_git_using_command fixup' -l rebase -f -d 'Do a rebase after commit'
 complete -c git -n '__fish_git_using_command fixup' -l no-rebase -f -d 'Don\'t do a rebase after commit'
 complete -c git -n '__fish_git_using_command fixup' -s b -l base -f -d 'Use <rev> as base of the revision range for the search]' -a '(__fish_git_refs)'

--- a/completion.zsh
+++ b/completion.zsh
@@ -21,5 +21,5 @@ _arguments -A \
     '(--rebase --no-rebase)'--rebase'[Do a rebase after commit]' \
     '(--rebase --no-rebase)'--no-rebase"[Don't do a rebase after commit]" \
     '(-b --base)'{-b,--base}+"[Use <rev> as base of the revision range for the search]":rev:__git_references \
-    '(--no-verify)'--no-verify'[Bypass the pre-commit and commit-msg hooks]' \
+    '(-n --no-verify)'{-n,--no-verify}'[Bypass the pre-commit and commit-msg hooks]' \
     ':commit:_fixup_target'

--- a/git-fixup
+++ b/git-fixup
@@ -11,7 +11,7 @@ c,commit      Show a menu from which to pick a commit
 no-commit     Don't show a menu to pick a commit
 rebase        Do a rebase right after commit
 no-rebase     Don't do a rebase after commit
-no-verify     Bypass the pre-commit and commit-msg hooks
+n,no-verify   Bypass the pre-commit and commit-msg hooks
 b,base=rev    Use <rev> as base of the revision range for the search
 "
 SUBDIRECTORY_OK=yes
@@ -166,7 +166,7 @@ while test $# -gt 0; do
         --no-rebase)
             rebase=false
             ;;
-        --no-verify)
+        -n|--no-verify)
             git_commit_args+=($1)
             ;;
         -b|--base)


### PR DESCRIPTION
`git commit` supports `-n` as short option for `--no-verify`. We here
now mirror that behavior.