### PR TITLE
Remove filenames in tab-completion in fish >= 3.5

### DIFF
--- a/completion.fish
+++ b/completion.fish
@@ -1,14 +1,14 @@
 # fish completion for git fixup
 
 function __fish_git_fixup_target
-    git fixup --no-commit --no-rebase 2>/dev/null | string replace -r '^([0-9a-f]{10})[0-9a-f]* (.*)' '$1\t$2'
+    git-fixup --no-commit --no-rebase 2>/dev/null | string replace -r '^([0-9a-f]{10})[0-9a-f]* (.*)' '$1\t$2'
 end
 
-complete -c git -n '__fish_git_using_command fixup' -s s -l squash -f -d 'Create a squash commit rather than a fixup'
-complete -c git -n '__fish_git_using_command fixup' -s c -l commit -f -d 'Show a menu to pick a commit'
-complete -c git -n '__fish_git_using_command fixup' -l no-commit -f -d 'Don\'t show a menu to pick a commit'
-complete -c git -n '__fish_git_using_command fixup' -s n -l no-verify -f -d 'Bypass the pre-commit and commit-msg hooks'
-complete -c git -n '__fish_git_using_command fixup' -l rebase -f -d 'Do a rebase after commit'
-complete -c git -n '__fish_git_using_command fixup' -l no-rebase -f -d 'Don\'t do a rebase after commit'
-complete -c git -n '__fish_git_using_command fixup' -s b -l base -f -d 'Use <rev> as base of the revision range for the search]' -a '(__fish_git_refs)'
-complete -c git -n '__fish_git_using_command fixup' -f -k -a '(__fish_git_fixup_target)'
+complete -c git-fixup -s s -l squash -f -d 'Create a squash commit rather than a fixup'
+complete -c git-fixup -s c -l commit -f -d 'Show a menu to pick a commit'
+complete -c git-fixup -l no-commit -f -d 'Don\'t show a menu to pick a commit'
+complete -c git-fixup -s n -l no-verify -f -d 'Bypass the pre-commit and commit-msg hooks'
+complete -c git-fixup -l rebase -f -d 'Do a rebase after commit'
+complete -c git-fixup -l no-rebase -f -d 'Don\'t do a rebase after commit'
+complete -c git-fixup -s b -l base -f -d 'Use <rev> as base of the revision range for the search]' -a '(__fish_git_refs)'
+complete -c git-fixup -f -k -a '(__fish_git_fixup_target)'


### PR DESCRIPTION
Fish 3.5 did speed up loading custom fish completions. But also changed its behaviour in https://github.com/fish-shell/fish-shell/commit/ff72e3f1543618095ffa03799a93b04f9f868a60. It is now necessary to define at least one custom completion for 'git-fixup'. That pointed to an easier way: Write completions for 'git-fixup' and fish will forward them from 'git fixup' https://github.com/fish-shell/fish-shell/commit/09161761c14f23dec8e8f681ff80140d828080b0