### PR TITLE
Add --all option

### DIFF
--- a/completion.fish
+++ b/completion.fish
@@ -11,4 +11,5 @@ complete -c git-fixup -s n -l no-verify -f -d 'Bypass the pre-commit and commit-
 complete -c git-fixup -l rebase -f -d 'Do a rebase after commit'
 complete -c git-fixup -l no-rebase -f -d 'Don\'t do a rebase after commit'
 complete -c git-fixup -s b -l base -x -d 'Use <rev> as base of the revision range for the search]' -a '(__fish_git_refs)'
+complete -c git-fixup -s A -l all -x -d 'Show all candidates'
 complete -c git-fixup -f -k -a '(__fish_git_fixup_target)'

--- a/completion.zsh
+++ b/completion.zsh
@@ -23,4 +23,5 @@ _arguments -A \
     '(--rebase --no-rebase)'--no-rebase"[Don't do a rebase after commit]" \
     '(-b --base)'{-b,--base}+"[Use <rev> as base of the revision range for the search]":rev:__git_references \
     '(-n --no-verify)'{-n,--no-verify}'[Bypass the pre-commit and commit-msg hooks]' \
+    '(-A --all)'{-a,--all}'[Show all candidates]' \
     ':commit:_fixup_target'

--- a/git-fixup
+++ b/git-fixup
@@ -14,6 +14,7 @@ rebase        Do a rebase right after commit
 no-rebase     Don't do a rebase after commit
 n,no-verify   Bypass the pre-commit and commit-msg hooks
 b,base=rev    Use <rev> as base of the revision range for the search
+A,all         Show all candidates
 "
 SUBDIRECTORY_OK=yes
 . "$(git --exec-path)/git-sh-setup"
@@ -55,6 +56,11 @@ function fixup_candidates_files () {
     ) | sed 's/^/F /g'
 }
 
+# Produce suggestion of all commits in $rev_range
+function fixup_candidates_all_commits () {
+	git rev-list $rev_range | sed 's/^/F /g'
+}
+
 # Pretty print details of a commit
 function print_sha () {
     local sha=$1
@@ -93,8 +99,12 @@ function call_rebase() {
 # Print list of fixup/squash candidates
 function print_candidates() {
     (
-        fixup_candidates_lines
-        fixup_candidates_files
+        if test "$show_all" == "false"; then
+            fixup_candidates_lines
+            fixup_candidates_files
+        else
+            fixup_candidates_all_commits
+        fi
     ) | sort -uk2 |  while read type sha; do
         if test "$sha" != ""; then
             print_sha "$sha" "$type"
@@ -152,6 +162,7 @@ rebase=${GITFIXUPREBASE:-$(git config --default=false fixup.rebase)}
 fixup_menu=${GITFIXUPMENU:-$(git config --default="" fixup.menu)}
 create_commit=${GITFIXUPCOMMIT:-$(git config --default=false --type bool fixup.commit)}
 base=${GITFIXUPBASE:-$(git config --default="" fixup.base)}
+show_all=false
 
 while test $# -gt 0; do
     case "$1" in
@@ -185,6 +196,9 @@ while test $# -gt 0; do
                 die "--base requires an argument"
             fi
             base="$1"
+            ;;
+        -A|--all)
+            show_all=true
             ;;
         --)
             shift


### PR DESCRIPTION
This new option allows to display all the commits in the range base..HEAD.

This option does not use all the smart closest commit search in the range. But it allows to use the interactive selection. It is usefull when the user does a modification unrelated to the target commit, and knows which commit it is. In that, it may do:
* git commit -m "fixfix"
* git rebase -i base

This new option saves one command, and is shorted to:
* git fixup -a -b base