### PR TITLE
Add --amend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ script into your `$PATH` and `$fpath` respectively.
 ## Usage
 
 ```
-git-fixup [-s|--squash] [-f|--fixup] [-c|--commit] [--no-verify]
+git-fixup [-s|--squash] [-f|--fixup] [-a|--amend] [-c|--commit] [--no-verify]
           [--rebase] [-b|--base <rev>] [<ref>]
 ```
 
@@ -75,6 +75,12 @@ Default action can be configured by setting [fixup.action](#fixupaction)
 ### -f, --fixup
 
 Instruct `git-fixup` to create `fixup!` commit (This is the default).
+
+Default action can be configured by setting [fixup.action](#fixupaction)
+
+### -a, --amend
+
+Instruct `git-fixup` to create an `amend!` commit.
 
 Default action can be configured by setting [fixup.action](#fixupaction)
 

--- a/completion.zsh
+++ b/completion.zsh
@@ -16,6 +16,7 @@ function _fixup_target {
 
 _arguments -A \
     '(-s --squash)'{-s,--squash}'[Create a squash commit rather than a fixup]' \
+    '(-a --amend)'{-a,--amend}'[Create an amend commit rather than a fixup]' \
     '(-c --commit --no-commit)'{-c,--commit}'[Create a commit]' \
     '(-c --commit --no-commit)'--no-commit"[Don't create a commit]" \
     '(--rebase --no-rebase)'--rebase'[Do a rebase after commit]' \

--- a/git-fixup
+++ b/git-fixup
@@ -7,6 +7,7 @@ git fixup [options] [<ref>]
 h,help        Show this help text
 s,squash      Create a squash! commit
 f,fixup       Create a fixup! commit
+a,amend       Create an amend! commit
 c,commit      Show a menu from which to pick a commit
 no-commit     Don't show a menu to pick a commit
 rebase        Do a rebase right after commit
@@ -64,9 +65,15 @@ function print_sha () {
 
 # Call git commit
 function call_commit() {
+    local flag=$op
     local target=$1
 
-    git commit ${git_commit_args[@]} --$op=$target
+    if test "$op" == "amend"; then
+        flag=fixup
+        target="amend:$target"
+    fi
+
+    git commit ${git_commit_args[@]} --$flag=$target
 }
 
 # Call git rebase
@@ -153,6 +160,9 @@ while test $# -gt 0; do
             ;;
         -f|--fixup)
             op="fixup"
+            ;;
+        -a|--amend)
+            op="amend"
             ;;
         -c|--commit)
             create_commit=true


### PR DESCRIPTION
Recent git releases accept a `--fixup=amend:<rev>` syntax that allows direct edition of the target commit's message, which can be seen as an improved version of the `--squash` option. Expose that functionality to users via a new option `--amend` (or `-a`).