### PR TITLE
Fail script if git-commit fails

### DIFF
--- a/git-fixup
+++ b/git-fixup
@@ -79,7 +79,7 @@ function call_commit() {
         target="amend:$target"
     fi
 
-    git commit ${git_commit_args[@]} --$flag=$target
+    git commit ${git_commit_args[@]} --$flag=$target || die
 }
 
 # Call git rebase


### PR DESCRIPTION
This is important to not call git rebase with a dirty repository state when the --rebase option is used.

Fixes #68