### PR TITLE
Install zsh completion with mode 644, add `install-fish` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ install:
 
 install-zsh:
 	${INSTALL} -d ${DESTDIR}${INSTALLDIR}/share/zsh/site-functions
-	${INSTALL} -m755 completion.zsh ${DESTDIR}${INSTALLDIR}/share/zsh/site-functions/_git-fixup
+	${INSTALL} -m644 completion.zsh ${DESTDIR}${INSTALLDIR}/share/zsh/site-functions/_git-fixup

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ install:
 	${INSTALL} -d ${DESTDIR}${INSTALLDIR}/bin
 	${INSTALL} -m755 git-fixup ${DESTDIR}${INSTALLDIR}/bin/git-fixup
 
+install-fish:
+	${INSTALL} -d ${DESTDIR}${INSTALLDIR}/share/fish/vendor_completions.d/
+	${INSTALL} -m644 completion.fish ${DESTDIR}${INSTALLDIR}/share/fish/vendor_completions.d/git-fixup.fish
+
 install-zsh:
 	${INSTALL} -d ${DESTDIR}${INSTALLDIR}/share/zsh/site-functions
 	${INSTALL} -m644 completion.zsh ${DESTDIR}${INSTALLDIR}/share/zsh/site-functions/_git-fixup


### PR DESCRIPTION
A few things I noticed when packaging git-fixup for Gentoo.